### PR TITLE
chore(types): typed req.user and validation improvements

### DIFF
--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,7 +1,6 @@
 import { RequestHandler } from "express";
 import jwt from "jsonwebtoken";
-
-type JwtPayload = { id: number; role: string; iat?: number; exp?: number };
+import { JwtPayload } from "../types/auth";
 
 export const authenticate: RequestHandler = (req, _res, next) => {
   try {
@@ -16,7 +15,7 @@ export const authenticate: RequestHandler = (req, _res, next) => {
       return next({ status: 500, message: "Server misconfiguration" });
     const payload = jwt.verify(token, secret) as JwtPayload;
     // attach user payload to req for downstream handlers
-    (req as any).user = payload;
+    req.user = payload;
     return next();
   } catch (err) {
     return next({ status: 401, message: "Invalid or expired token" });
@@ -24,7 +23,7 @@ export const authenticate: RequestHandler = (req, _res, next) => {
 };
 
 export const requireAdmin: RequestHandler = (req, _res, next) => {
-  const user = (req as any).user as JwtPayload | undefined;
+  const user = req.user as JwtPayload | undefined;
   if (!user) return next({ status: 401, message: "Not authenticated" });
   if (user.role !== "ADMIN")
     return next({ status: 403, message: "Admin required" });

--- a/api/src/middleware/validate.ts
+++ b/api/src/middleware/validate.ts
@@ -2,7 +2,9 @@ import { RequestHandler } from "express";
 import z from "zod";
 
 // validateBody(schema) returns middleware that validates req.body with the provided Zod schema
-export function validateBody(schema: z.ZodTypeAny): RequestHandler {
+export function validateBody<T extends z.ZodTypeAny>(
+  schema: T
+): RequestHandler<any, any, z.infer<T>> {
   return (req, _res, next) => {
     const result = schema.safeParse(req.body);
     if (!result.success) {
@@ -13,7 +15,7 @@ export function validateBody(schema: z.ZodTypeAny): RequestHandler {
       return next({ status: 400, message: "Invalid data", errors });
     }
     // replace body with the parsed/validated data
-    req.body = result.data as any;
+    req.body = result.data;
     return next();
   };
 }

--- a/api/src/types/auth.ts
+++ b/api/src/types/auth.ts
@@ -1,0 +1,6 @@
+export type JwtPayload = {
+  id: number;
+  role: "USER" | "ADMIN" | string;
+  iat?: number;
+  exp?: number;
+};

--- a/api/src/types/express.d.ts
+++ b/api/src/types/express.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  namespace Express {
+    interface Request {
+      // reuse the JwtPayload shape from src/types/auth.ts
+      user?: import("../types/auth").JwtPayload;
+    }
+  }
+}
+
+export {};

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -9,6 +9,6 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/types/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR adds TypeScript typing improvements:\n- Add JwtPayload type and reuse it in express Request augmentation\n- Make validateBody middleware generic to avoid as any casts\n\nAll tests pass locally.